### PR TITLE
Discarding the master and slave words

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -199,8 +199,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -224,11 +224,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
         
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
         
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
         
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -260,7 +260,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
                 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -299,15 +299,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -444,16 +444,16 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
         params = {
-            'Instances.MasterInstanceType' : master_instance_type,
-            'Instances.SlaveInstanceType' : slave_instance_type,
+            'Instances.MainInstanceType' : main_instance_type,
+            'Instances.SubordinateInstanceType' : subordinate_instance_type,
             'Instances.InstanceCount' : num_instances,
             }
         return params

--- a/boto/emr/step.py
+++ b/boto/emr/step.py
@@ -124,7 +124,7 @@ class StreamingStep(Step):
         :type output: str
         :param output: The output uri
         :type jar: str
-        :param jar: The hadoop streaming jar. This can be either a local path on the master node, or an s3:// URI.
+        :param jar: The hadoop streaming jar. This can be either a local path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/boto/emr/tests/test_emr_responses.py
+++ b/boto/emr/tests/test_emr_responses.py
@@ -70,8 +70,8 @@ JOB_FLOW_EXAMPLE = """
           <Placement>
             <AvailabilityZone>us-east-1a</AvailabilityZone>
           </Placement>
-          <SlaveInstanceType>m1.small</SlaveInstanceType>
-          <MasterInstanceType>m1.small</MasterInstanceType>
+          <SubordinateInstanceType>m1.small</SubordinateInstanceType>
+          <MainInstanceType>m1.small</MainInstanceType>
           <Ec2KeyName>myec2keyname</Ec2KeyName>
           <InstanceCount>4</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
@@ -266,8 +266,8 @@ JOB_FLOW_COMPLETED = """
         </Steps>
         <JobFlowId>j-3H3Q13JPFLU22</JobFlowId>
         <Instances>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-64c21609</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-64c21609</MainInstanceId>
           <Placement>
             <AvailabilityZone>us-east-1b</AvailabilityZone>
           </Placement>
@@ -285,7 +285,7 @@ JOB_FLOW_COMPLETED = """
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>MASTER</InstanceRole>
               <InstanceGroupId>ig-EVMHOZJ2SCO8</InstanceGroupId>
-              <Name>master</Name>
+              <Name>main</Name>
             </member>
             <member>
               <CreationDateTime>2010-10-21T01:00:25Z</CreationDateTime>
@@ -300,13 +300,13 @@ JOB_FLOW_COMPLETED = """
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>CORE</InstanceRole>
               <InstanceGroupId>ig-YZHDYVITVHKB</InstanceGroupId>
-              <Name>slave</Name>
+              <Name>subordinate</Name>
             </member>
           </InstanceGroups>
           <NormalizedInstanceHours>40</NormalizedInstanceHours>
           <HadoopVersion>0.20</HadoopVersion>
-          <MasterInstanceType>m1.large</MasterInstanceType>
-          <MasterPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MasterPublicDnsName>
+          <MainInstanceType>m1.large</MainInstanceType>
+          <MainPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MainPublicDnsName>
           <Ec2KeyName>myubersecurekey</Ec2KeyName>
           <InstanceCount>10</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>false</KeepJobFlowAliveWhenNoSteps>
@@ -346,8 +346,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='mybucket/subdir/',
                             name='MyJobFlowName',
                             availabilityzone='us-east-1a',
-                            slaveinstancetype='m1.small',
-                            masterinstancetype='m1.small',
+                            subordinateinstancetype='m1.small',
+                            maininstancetype='m1.small',
                             ec2keyname='myec2keyname',
                             keepjobflowalivewhennosteps='true')
 
@@ -364,8 +364,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='s3n://example.emrtest.scripts/jobflow_logs/',
                             name='RealJobFlowName',
                             availabilityzone='us-east-1b',
-                            slaveinstancetype='m1.large',
-                            masterinstancetype='m1.large',
+                            subordinateinstancetype='m1.large',
+                            maininstancetype='m1.large',
                             ec2keyname='myubersecurekey',
                             keepjobflowalivewhennosteps='false')
         self.assertEquals(6, len(jobflow.steps))

--- a/boto/pyami/bootstrap.py
+++ b/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/boto/rds/__init__.py
+++ b/boto/rds/__init__.py
@@ -134,7 +134,7 @@ class RDSConnection(AWSQueryConnection):
                              [('DBInstance', DBInstance)])
 
     def create_dbinstance(self, id, allocated_storage, instance_class,
-                          master_username, master_password, port=3306,
+                          main_username, main_password, port=3306,
                           engine='MySQL5.1', db_name=None, param_group=None,
                           security_groups=None, availability_zone=None,
                           preferred_maintenance_window=None,
@@ -170,13 +170,13 @@ class RDSConnection(AWSQueryConnection):
         :type engine: str
         :param engine: Name of database engine. Must be MySQL5.1 for now.
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
                                 Must be 1-15 alphanumeric characters, first
                                 must be a letter.
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-16 alphanumeric characters.
 
         :type port: int
@@ -237,8 +237,8 @@ class RDSConnection(AWSQueryConnection):
                   'AllocatedStorage': allocated_storage,
                   'DBInstanceClass': instance_class,
                   'Engine': engine,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'Port': port,
                   'MultiAZ': str(multi_az).lower(),
                   'AutoMinorVersionUpgrade':
@@ -339,7 +339,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -361,8 +361,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -420,8 +420,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'DBSecurityGroups.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/boto/rds/dbinstance.py
+++ b/boto/rds/dbinstance.py
@@ -36,7 +36,7 @@ class DBInstance(object):
         self.allocated_storage = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_group = None
         self.security_group = None
         self.availability_zone = None
@@ -82,8 +82,8 @@ class DBInstance(object):
             self.allocated_storage = int(value)
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -176,7 +176,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -195,8 +195,8 @@ class DBInstance(object):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -245,7 +245,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/boto/rds/dbsnapshot.py
+++ b/boto/rds/dbsnapshot.py
@@ -33,7 +33,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -61,8 +61,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.